### PR TITLE
Fixes MAISTRA-1226: fix for ScopedEVP_MD_CTX used in UtilityImpl::verifySignature

### DIFF
--- a/bssl_wrapper/bssl_wrapper.cc
+++ b/bssl_wrapper/bssl_wrapper.cc
@@ -2,25 +2,11 @@
 
 int EVP_MD_CTX_cleanup(EVP_MD_CTX *ctx) {
   EVP_MD_CTX_free(ctx);
-  ctx = EVP_MD_CTX_new();
-
-//  OPENSSL_free(ctx->md_data);
-
-//  assert(ctx->pctx == NULL || ctx->pctx_ops != NULL);
-//  if (ctx->pctx_ops) {
-//    ctx->pctx_ops->free(ctx->pctx);
-//  }
-
-//  EVP_MD_CTX_init(ctx);
-
   return 1;
 }
 
-void EVP_MD_CTX_initialize(EVP_MD_CTX *ctx) {
-  EVP_MD_CTX_free(ctx);
-  ctx = EVP_MD_CTX_new();
-
-//  OPENSSL_memset(ctx, 0, sizeof(EVP_MD_CTX));
+EVP_MD_CTX* EVP_MD_CTX_initialize() {
+  return EVP_MD_CTX_new();
 }
 
 int BIO_mem_contents(const BIO *bio, const uint8_t **out_contents,

--- a/bssl_wrapper/bssl_wrapper.h
+++ b/bssl_wrapper/bssl_wrapper.h
@@ -45,7 +45,7 @@ class StackAllocated {
 
   void Reset() {
     cleanup(ctx_);
-    init();
+    ctx_ = init();
   }
 
  private:


### PR DESCRIPTION
This is the first part of a fix for https://issues.redhat.com/browse/MAISTRA-1226. The second part is here: https://github.com/Maistra/envoy/pull/6